### PR TITLE
Feat/41 chat report

### DIFF
--- a/backend/src/main/java/com/coing/domain/bookmark/controller/BookmarkController.kt
+++ b/backend/src/main/java/com/coing/domain/bookmark/controller/BookmarkController.kt
@@ -10,6 +10,7 @@ import com.coing.global.exception.doc.ErrorCode
 import com.coing.util.BasicResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
@@ -19,6 +20,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 
+@Tag(name = "BookMark API", description = "북마크 관련 API 엔드포인트")
 @RestController
 @RequestMapping("/api")
 class BookmarkController(

--- a/backend/src/main/java/com/coing/domain/chat/controller/ChatController.kt
+++ b/backend/src/main/java/com/coing/domain/chat/controller/ChatController.kt
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
 import java.time.ZoneOffset
 
 @RestController
@@ -16,17 +17,20 @@ import java.time.ZoneOffset
 class ChatController(
     private val chatService: ChatService
 ) {
-
-    // 채팅방의 메시지 목록 조회 (marketCode 기준)
+    // 채팅방의 메시지 목록 조회 (marketCode 기준, 최근 10분 메시지 캐시 조회)
     @GetMapping("/rooms/{marketCode}/messages")
     fun getMessagesByMarket(@PathVariable("marketCode") marketCode: String): ResponseEntity<List<ChatMessageDto>> {
         // 채팅방 조회 (없으면 생성)
         val chatRoom: ChatRoom = chatService.getOrCreateChatRoomByMarketCode(marketCode)
-        // 채팅방의 ID는 null이 아님을 보장한다고 가정
+        // 캐시에서 해당 채팅방의 메시지 리스트를 조회 (만약 캐시에 없다면 빈 리스트 반환)
         val messages: List<ChatMessage> = chatService.getMessages(chatRoom.id!!)
 
+        // 최근 10분 이내의 메시지 필터링
+        val cutoffTime = LocalDateTime.now().minusMinutes(10)
+        val recentMessages = messages.filter { it.timestamp?.isAfter(cutoffTime) == true }
+
         // 엔티티를 DTO로 변환하여 반환
-        val dtos: List<ChatMessageDto> = messages.map { message ->
+        val dtos: List<ChatMessageDto> = recentMessages.map { message ->
             ChatMessageDto(
                 sender = message.sender?.name ?: "",
                 content = message.content,

--- a/backend/src/main/java/com/coing/domain/chat/controller/ChatController.kt
+++ b/backend/src/main/java/com/coing/domain/chat/controller/ChatController.kt
@@ -7,6 +7,7 @@ import com.coing.domain.chat.service.ChatService
 import com.coing.global.exception.doc.ApiErrorCodeExamples
 import com.coing.global.exception.doc.ErrorCode
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 
+@Tag(name = "Chat API", description = "채팅 관련 API 엔드포인트")
 @RestController
 @RequestMapping("/api/chat")
 class ChatController(

--- a/backend/src/main/java/com/coing/domain/chat/controller/ChatController.kt
+++ b/backend/src/main/java/com/coing/domain/chat/controller/ChatController.kt
@@ -4,6 +4,8 @@ import com.coing.domain.chat.dto.ChatMessageDto
 import com.coing.domain.chat.entity.ChatMessage
 import com.coing.domain.chat.entity.ChatRoom
 import com.coing.domain.chat.service.ChatService
+import com.coing.global.exception.doc.ApiErrorCodeExamples
+import com.coing.global.exception.doc.ErrorCode
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -20,6 +22,7 @@ class ChatController(
 ) {
     // 채팅방의 메시지 목록 조회 (marketCode 기준, 최근 10분 메시지 캐시 조회)
     @Operation(summary = "채팅방 메세지 목록 조회 - 최근 10분")
+    @ApiErrorCodeExamples(ErrorCode.MARKET_NOT_FOUND, ErrorCode.CHAT_ROOM_NOT_FOUND, ErrorCode.INTERNAL_SERVER_ERROR)
     @GetMapping("/rooms/{marketCode}/messages")
     fun getMessagesByMarket(@PathVariable("marketCode") marketCode: String): ResponseEntity<List<ChatMessageDto>> {
         // 채팅방 조회 (없으면 생성)

--- a/backend/src/main/java/com/coing/domain/chat/controller/ChatController.kt
+++ b/backend/src/main/java/com/coing/domain/chat/controller/ChatController.kt
@@ -4,6 +4,7 @@ import com.coing.domain.chat.dto.ChatMessageDto
 import com.coing.domain.chat.entity.ChatMessage
 import com.coing.domain.chat.entity.ChatRoom
 import com.coing.domain.chat.service.ChatService
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -18,6 +19,7 @@ class ChatController(
     private val chatService: ChatService
 ) {
     // 채팅방의 메시지 목록 조회 (marketCode 기준, 최근 10분 메시지 캐시 조회)
+    @Operation(summary = "채팅방 메세지 목록 조회 - 최근 10분")
     @GetMapping("/rooms/{marketCode}/messages")
     fun getMessagesByMarket(@PathVariable("marketCode") marketCode: String): ResponseEntity<List<ChatMessageDto>> {
         // 채팅방 조회 (없으면 생성)

--- a/backend/src/main/java/com/coing/domain/chat/controller/ChatReportController.kt
+++ b/backend/src/main/java/com/coing/domain/chat/controller/ChatReportController.kt
@@ -8,11 +8,13 @@ import com.coing.global.exception.doc.ApiErrorCodeExamples
 import com.coing.global.exception.doc.ErrorCode
 import com.coing.util.BasicResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 
+@Tag(name = "ChatReport API", description = "채팅 신고 관련 API 엔드포인트")
 @RestController
 @RequestMapping("/api/chat/messages")
 class ChatReportController(

--- a/backend/src/main/java/com/coing/domain/chat/controller/ChatReportController.kt
+++ b/backend/src/main/java/com/coing/domain/chat/controller/ChatReportController.kt
@@ -1,0 +1,48 @@
+package com.coing.domain.chat.controller
+
+import com.coing.domain.chat.entity.ChatMessage
+import com.coing.domain.chat.service.ChatReportService
+import com.coing.domain.chat.service.ChatService
+import com.coing.domain.user.entity.User
+import com.coing.util.BasicResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/chat/messages")
+class ChatReportController(
+    private val chatService: ChatService,
+    private val chatReportService: ChatReportService
+) {
+
+    /**
+     * 신고 API
+     *
+     * 경로: /api/chat/messages/{messageId}/report
+     * HTTP 메서드: POST
+     *
+     * @param messageId 신고할 메시지의 ID
+     * @param currentUser 현재 인증된 사용자 (신고자)
+     */
+    @PostMapping("/{messageId}/report")
+    fun reportMessage(
+        @PathVariable messageId: Long,
+        @AuthenticationPrincipal currentUser: User
+    ): ResponseEntity<BasicResponse> {
+        val message: ChatMessage = chatService.findMessageById(messageId)
+            ?: return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(BasicResponse(HttpStatus.NOT_FOUND, "메시지를 찾을 수 없습니다.", ""))
+
+        return try {
+            // 신고를 처리하고 신고 내역을 DB에 저장
+            chatReportService.reportMessage(message, currentUser)
+            ResponseEntity.ok(BasicResponse(HttpStatus.OK, "메시지가 신고되었습니다.", ""))
+        } catch (e: Exception) {
+            ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(BasicResponse(HttpStatus.BAD_REQUEST, e.message ?: "신고에 실패했습니다.", ""))
+        }
+    }
+
+}

--- a/backend/src/main/java/com/coing/domain/chat/controller/ChatReportController.kt
+++ b/backend/src/main/java/com/coing/domain/chat/controller/ChatReportController.kt
@@ -5,6 +5,7 @@ import com.coing.domain.chat.service.ChatReportService
 import com.coing.domain.chat.service.ChatService
 import com.coing.domain.user.entity.User
 import com.coing.util.BasicResponse
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -26,6 +27,7 @@ class ChatReportController(
      * @param messageId 신고할 메시지의 ID
      * @param currentUser 현재 인증된 사용자 (신고자)
      */
+    @Operation(summary = "메세지 신고하기")
     @PostMapping("/{messageId}/report")
     fun reportMessage(
         @PathVariable messageId: Long,

--- a/backend/src/main/java/com/coing/domain/chat/controller/ChatReportController.kt
+++ b/backend/src/main/java/com/coing/domain/chat/controller/ChatReportController.kt
@@ -4,6 +4,8 @@ import com.coing.domain.chat.entity.ChatMessage
 import com.coing.domain.chat.service.ChatReportService
 import com.coing.domain.chat.service.ChatService
 import com.coing.domain.user.entity.User
+import com.coing.global.exception.doc.ApiErrorCodeExamples
+import com.coing.global.exception.doc.ErrorCode
 import com.coing.util.BasicResponse
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.HttpStatus
@@ -28,6 +30,12 @@ class ChatReportController(
      * @param currentUser 현재 인증된 사용자 (신고자)
      */
     @Operation(summary = "메세지 신고하기")
+    @ApiErrorCodeExamples(
+        ErrorCode.MESSAGE_NOT_FOUND,
+        ErrorCode.MESSAGE_ALREADY_REPORTED,
+        ErrorCode.MEMBER_NOT_FOUND,
+        ErrorCode.MESSAGE_REPORT_FAILED,
+        ErrorCode.INTERNAL_SERVER_ERROR)
     @PostMapping("/{messageId}/report")
     fun reportMessage(
         @PathVariable messageId: Long,

--- a/backend/src/main/java/com/coing/domain/chat/dto/ChatMessageReportDto.kt
+++ b/backend/src/main/java/com/coing/domain/chat/dto/ChatMessageReportDto.kt
@@ -1,0 +1,8 @@
+package com.coing.domain.chat.dto
+
+import com.coing.domain.chat.entity.ChatMessage
+
+data class ChatMessageReportDto(
+    val chatMessage: ChatMessage,
+    val reportCount: Long
+)

--- a/backend/src/main/java/com/coing/domain/chat/entity/ChatMessageReport.kt
+++ b/backend/src/main/java/com/coing/domain/chat/entity/ChatMessageReport.kt
@@ -1,0 +1,33 @@
+package com.coing.domain.chat.entity
+
+import com.coing.domain.user.entity.User
+import com.coing.global.annotation.NoArg
+import com.coing.util.BaseEntity
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "chat_message_reports",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["chat_message_id", "reporter_id"])]
+)
+@NoArg
+data class ChatMessageReport(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    // 신고 대상 메시지
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_message_id", nullable = false)
+    val chatMessage: ChatMessage,
+
+    // 신고한 사용자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    val reporter: User,
+
+    // 신고 일시
+    @Column(name = "reported_at", nullable = false)
+    val reportedAt: LocalDateTime = LocalDateTime.now()
+) : BaseEntity()

--- a/backend/src/main/java/com/coing/domain/chat/repository/ChatMessageReportRepository.kt
+++ b/backend/src/main/java/com/coing/domain/chat/repository/ChatMessageReportRepository.kt
@@ -1,0 +1,18 @@
+package com.coing.domain.chat.repository
+
+import com.coing.domain.chat.entity.ChatMessageReport
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface ChatMessageReportRepository : JpaRepository<ChatMessageReport, Long> {
+
+    fun findByChatMessageIdAndReporterId(chatMessageId: Long, reporterId: java.util.UUID): ChatMessageReport?
+
+    // 신고된 메시지를 그룹화하여, 신고 횟수가 threshold 이상인 메시지를 DTO로 반환
+    @Query(
+        "SELECT new com.coing.domain.chat.dto.ChatMessageReportDto(r.chatMessage, COUNT(r)) " +
+                "FROM ChatMessageReport r GROUP BY r.chatMessage HAVING COUNT(r) >= :threshold"
+    )
+    fun findReportedMessages(@Param("threshold") threshold: Long): List<com.coing.domain.chat.dto.ChatMessageReportDto>
+}

--- a/backend/src/main/java/com/coing/domain/chat/repository/ChatMessageRepository.kt
+++ b/backend/src/main/java/com/coing/domain/chat/repository/ChatMessageRepository.kt
@@ -2,7 +2,10 @@ package com.coing.domain.chat.repository
 
 import com.coing.domain.chat.entity.ChatMessage
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
+@Repository
 interface ChatMessageRepository : JpaRepository<ChatMessage, Long> {
-    fun findByChatRoomIdOrderByTimestampAsc(chatRoomId: Long): List<ChatMessage>
+    fun findAllByChatRoomIdAndTimestampAfter(chatRoomId: Long, timestamp: LocalDateTime): List<ChatMessage>
 }

--- a/backend/src/main/java/com/coing/domain/chat/service/ChatReportService.kt
+++ b/backend/src/main/java/com/coing/domain/chat/service/ChatReportService.kt
@@ -1,0 +1,34 @@
+package com.coing.domain.chat.service
+
+import com.coing.domain.chat.entity.ChatMessage
+import com.coing.domain.chat.entity.ChatMessageReport
+import com.coing.domain.chat.dto.ChatMessageReportDto
+import com.coing.domain.chat.repository.ChatMessageReportRepository
+import com.coing.domain.user.entity.User
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ChatReportService(
+    private val chatMessageReportRepository: ChatMessageReportRepository
+) {
+    @Transactional
+    fun reportMessage(chatMessage: ChatMessage, reporter: User): ChatMessageReport {
+        chatMessage.id?.let {
+            // 동일 메시지에 대해 같은 사용자가 이미 신고했는지 확인
+            val existingReport = chatMessageReportRepository.findByChatMessageIdAndReporterId(it, reporter.id!!)
+            if (existingReport != null) {
+                throw IllegalArgumentException("이미 신고한 메시지입니다.")
+            }
+        }
+        val report = ChatMessageReport(
+            chatMessage = chatMessage,
+            reporter = reporter
+        )
+        return chatMessageReportRepository.save(report)
+    }
+
+    fun getReportedMessages(threshold: Long = 3): List<ChatMessageReportDto> {
+        return chatMessageReportRepository.findReportedMessages(threshold)
+    }
+}

--- a/backend/src/main/java/com/coing/domain/chat/service/ChatService.kt
+++ b/backend/src/main/java/com/coing/domain/chat/service/ChatService.kt
@@ -18,11 +18,11 @@ import java.util.concurrent.atomic.AtomicLong
 @Service
 class ChatService(
     private val chatRoomRepository: ChatRoomRepository,
-    private val chatMessageRepository: ChatMessageRepository,
+    private val chatMessageRepository: ChatMessageRepository, // 생성자 주입
     private val marketService: MarketService,
+    // 캐시에는 채팅방 ID별 메시지 리스트를 저장 (불변 리스트 타입)
     private val chatMessageCache: Cache<Long, List<ChatMessage>>
 ) {
-
     private val messageIdSequence = AtomicLong(1)
     private val log = LoggerFactory.getLogger(ChatService::class.java)
 
@@ -31,7 +31,7 @@ class ChatService(
         return chatRoomRepository.findByMarketCode(marketCode).orElseGet {
             // 마켓 정보 조회
             val market: Market = marketService.getCachedMarketByCode(marketCode)
-            // 새로운 ChatRoom 인스턴스 생성 (builder 없이 생성자 호출)
+            // 새로운 ChatRoom 인스턴스 생성
             val chatRoom = ChatRoom(
                 market = market,
                 name = "${market.koreanName} 채팅방"
@@ -45,7 +45,7 @@ class ChatService(
         val chatRoom = chatRoomRepository.findById(chatRoomId)
             .orElseThrow { RuntimeException("Chat room not found") }
 
-        // 새로운 ChatMessage 인스턴스 생성 (builder 대신 생성자 호출)
+        // 새로운 ChatMessage 인스턴스 생성
         val message = ChatMessage(
             id = messageIdSequence.getAndIncrement(),
             chatRoom = chatRoom,
@@ -54,7 +54,7 @@ class ChatService(
             timestamp = LocalDateTime.now()
         )
 
-        // 스레드 세이프한 리스트로 캐시에 저장
+        // 캐시에 메시지 저장 (실시간 처리를 위해)
         val messages = chatMessageCache.getIfPresent(chatRoomId)?.toMutableList()
             ?: CopyOnWriteArrayList<ChatMessage>()
         messages.add(message)
@@ -67,5 +67,36 @@ class ChatService(
     @Transactional(readOnly = true)
     fun getMessages(chatRoomId: Long): List<ChatMessage> {
         return chatMessageCache.getIfPresent(chatRoomId) ?: CopyOnWriteArrayList()
+    }
+
+    // 신고 시 DB에 해당 메시지(신고 대상)를 바로 영구 저장하는 로직
+    @Transactional
+    fun persistReportedMessage(chatMessage: ChatMessage): ChatMessage {
+        // 신고된 메시지를 DB에 저장
+        val persistedMessage = chatMessageRepository.save(chatMessage)
+        log.info("Persisted reported message {} for chat room {}", persistedMessage.id, chatMessage.chatRoom?.id)
+
+        // 캐시에 저장되어 있다면, 해당 메시지를 제거하여 중복 저장을 방지합니다.
+        chatMessage.chatRoom?.id?.let { roomId ->
+            chatMessageCache.getIfPresent(roomId)?.let { currentMessages ->
+                // List가 불변일 수 있으므로, 변경 가능한 리스트로 변환 후 삭제
+                val mutableMessages = currentMessages.toMutableList()
+                val removed = mutableMessages.removeIf { it.id == chatMessage.id }
+                if (removed) {
+                    chatMessageCache.put(roomId, mutableMessages)
+                    log.info("Removed reported message {} from cache for chat room {}", chatMessage.id, roomId)
+                }
+            }
+        }
+        return persistedMessage
+    }
+
+    @Transactional(readOnly = true)
+    fun findMessageById(messageId: Long): ChatMessage? {
+        // 우선 캐시에서 찾고, 없으면 DB에서 조회
+        chatMessageCache.asMap().values.forEach { messages ->
+            messages.find { it.id == messageId }?.let { return it }
+        }
+        return chatMessageRepository.findById(messageId).orElse(null)
     }
 }

--- a/backend/src/main/java/com/coing/domain/coin/candle/controller/CandleController.kt
+++ b/backend/src/main/java/com/coing/domain/coin/candle/controller/CandleController.kt
@@ -2,6 +2,7 @@ package com.coing.domain.coin.candle.controller
 
 import com.coing.domain.coin.candle.dto.CandleDto
 import com.coing.domain.coin.candle.service.UpbitCandleService
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "Candle API", description = "캔들 차트 관련 API 엔드포인트")
 @RestController
 @RequestMapping("/api/candles")
 class CandleController(

--- a/backend/src/main/java/com/coing/domain/news/controller/NewsController.kt
+++ b/backend/src/main/java/com/coing/domain/news/controller/NewsController.kt
@@ -2,6 +2,7 @@ package com.coing.domain.news.controller
 
 import com.coing.domain.news.service.NewsService
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "News API", description = "뉴스 관련 API 엔드포인트")
 @RestController
 @RequestMapping("/api")
 class NewsController(

--- a/backend/src/main/java/com/coing/domain/user/controller/AdminController.kt
+++ b/backend/src/main/java/com/coing/domain/user/controller/AdminController.kt
@@ -2,6 +2,8 @@ package com.coing.domain.user.controller
 
 import com.coing.domain.chat.dto.ChatMessageReportDto
 import com.coing.domain.chat.service.ChatReportService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
@@ -10,11 +12,13 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/admin")
+@Tag(name = "Admin API", description = "관리자 관련 API 엔드포인트")
 class AdminController(
     private val chatReportService: ChatReportService
 ) {
 
     // ADMIN 권한만 접근할 수 있도록 설정
+    @Operation(summary = "신고된 메시지 조회", description = "신고된 메시지를 조회합니다.")
     @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     @GetMapping("/reported-messages")
     fun getReportedMessages(): ResponseEntity<List<ChatMessageReportDto>> {

--- a/backend/src/main/java/com/coing/domain/user/controller/AdminController.kt
+++ b/backend/src/main/java/com/coing/domain/user/controller/AdminController.kt
@@ -2,6 +2,8 @@ package com.coing.domain.user.controller
 
 import com.coing.domain.chat.dto.ChatMessageReportDto
 import com.coing.domain.chat.service.ChatReportService
+import com.coing.global.exception.doc.ApiErrorCodeExamples
+import com.coing.global.exception.doc.ErrorCode
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
@@ -19,6 +21,12 @@ class AdminController(
 
     // ADMIN 권한만 접근할 수 있도록 설정
     @Operation(summary = "신고된 메시지 조회", description = "신고된 메시지를 조회합니다.")
+    @ApiErrorCodeExamples(
+        ErrorCode.REPORT_NOT_FOUND,
+        ErrorCode.INVALID_TOKEN,
+        ErrorCode.TOKEN_REQUIRED,
+        ErrorCode.INTERNAL_SERVER_ERROR
+    )
     @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     @GetMapping("/reported-messages")
     fun getReportedMessages(): ResponseEntity<List<ChatMessageReportDto>> {

--- a/backend/src/main/java/com/coing/domain/user/controller/AdminController.kt
+++ b/backend/src/main/java/com/coing/domain/user/controller/AdminController.kt
@@ -1,0 +1,24 @@
+package com.coing.domain.user.controller
+
+import com.coing.domain.chat.dto.ChatMessageReportDto
+import com.coing.domain.chat.service.ChatReportService
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/admin")
+class AdminController(
+    private val chatReportService: ChatReportService
+) {
+
+    // ADMIN 권한만 접근할 수 있도록 설정
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    @GetMapping("/reported-messages")
+    fun getReportedMessages(): ResponseEntity<List<ChatMessageReportDto>> {
+        val reportedMessages = chatReportService.getReportedMessages(3)
+        return ResponseEntity.ok(reportedMessages)
+    }
+}

--- a/backend/src/main/java/com/coing/domain/user/controller/dto/UserResponse.kt
+++ b/backend/src/main/java/com/coing/domain/user/controller/dto/UserResponse.kt
@@ -1,5 +1,6 @@
 package com.coing.domain.user.controller.dto
 
+import com.coing.domain.user.entity.Authority
 import com.coing.domain.user.entity.User
 import com.coing.global.annotation.NoArg
 import java.util.UUID
@@ -9,7 +10,8 @@ data class UserResponse(
     val id: UUID,
     val name: String,
     val email: String,
-    val verified: Boolean
+    val verified: Boolean,
+    val authority: Authority = Authority.ROLE_USER
 ) {
     companion object {
         fun from(user: User): UserResponse {
@@ -17,7 +19,8 @@ data class UserResponse(
                 id = user.id!!,
                 name = user.name,
                 email = user.email,
-                verified = user.verified
+                verified = user.verified,
+                authority = user.authority ?: Authority.ROLE_USER
             )
         }
     }

--- a/backend/src/main/java/com/coing/domain/user/dto/CustomUserPrincipal.kt
+++ b/backend/src/main/java/com/coing/domain/user/dto/CustomUserPrincipal.kt
@@ -1,7 +1,11 @@
 package com.coing.domain.user.dto
 
+import org.springframework.security.core.GrantedAuthority
 import java.util.UUID
 
-data class CustomUserPrincipal(val id: UUID) {
+data class CustomUserPrincipal(
+    val id: UUID,
+    val authorities: List<GrantedAuthority> = emptyList()
+) {
     override fun toString(): String = id.toString()
 }

--- a/backend/src/main/java/com/coing/domain/user/entity/Authority.kt
+++ b/backend/src/main/java/com/coing/domain/user/entity/Authority.kt
@@ -1,6 +1,6 @@
 package com.coing.domain.user.entity
 
 enum class Authority {
-    USER,
-    ADMIN
+    ROLE_USER,
+    ROLE_ADMIN
 }

--- a/backend/src/main/java/com/coing/domain/user/entity/User.kt
+++ b/backend/src/main/java/com/coing/domain/user/entity/User.kt
@@ -28,6 +28,7 @@ data class User(
     val password: String = "",
 
     // 권한 (값이 없을 경우 prePersist()에서 Authority.USER 로 설정)
+    @Enumerated(EnumType.STRING)
     @Column(name = "authority", nullable = false)
     var authority: Authority? = null,
 
@@ -43,7 +44,7 @@ data class User(
     @PrePersist
     fun prePersist() {
         if (authority == null) {
-            authority = Authority.USER
+            authority = Authority.ROLE_USER
         }
         // 가입 시각 기록 필드가 필요하다면 추가하세요.
         // if (createdAt == null) {

--- a/backend/src/main/java/com/coing/domain/user/service/AuthTokenService.kt
+++ b/backend/src/main/java/com/coing/domain/user/service/AuthTokenService.kt
@@ -29,7 +29,7 @@ class AuthTokenService {
     fun genAccessToken(userResponse: UserResponse): String {
         val claims: MutableMap<String, Any> = HashMap()
         claims["id"] = userResponse.id
-        // claims["authority"] = userResponse.authority // 나중에 권한 관련 추가
+        claims["authority"] = userResponse.authority
         val token = Ut.Jwt.createToken(jwtSecretKey, jwtExpireSeconds, claims)
         log.info("JWT 액세스 토큰 생성: {}", userResponse.email)
         return token
@@ -39,6 +39,7 @@ class AuthTokenService {
     fun genRefreshToken(userResponse: UserResponse): String {
         val claims: MutableMap<String, Any> = HashMap()
         claims["id"] = userResponse.id
+        claims["authority"] = userResponse.authority
         val token = Ut.Jwt.createToken(jwtSecretKey, jwtRefreshExpireSeconds, claims)
         log.info("JWT 리프레시 토큰 생성: {}", userResponse.email)
         return token

--- a/backend/src/main/java/com/coing/global/config/SecurityConfig.kt
+++ b/backend/src/main/java/com/coing/global/config/SecurityConfig.kt
@@ -40,7 +40,12 @@ class SecurityConfig(
 			.csrf(AbstractHttpConfigurer<*, *>::disable)
 			.headers { it.frameOptions { frameOptions -> frameOptions.disable() } }
 			.sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
-			.authorizeHttpRequests { it.anyRequest().permitAll() }
+			.authorizeHttpRequests { auth ->
+				auth
+					.requestMatchers("/api/admin/**").hasAuthority("ROLE_ADMIN")
+					.requestMatchers("/api/auth/**", "/oauth2/**").permitAll()
+					.anyRequest().authenticated()
+			}
 			.exceptionHandling { it.authenticationEntryPoint(customAuthenticationEntryPoint) }
 			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
 			.oauth2Login { oauth2 ->

--- a/backend/src/main/java/com/coing/global/config/SecurityConfig.kt
+++ b/backend/src/main/java/com/coing/global/config/SecurityConfig.kt
@@ -43,8 +43,7 @@ class SecurityConfig(
 			.authorizeHttpRequests { auth ->
 				auth
 					.requestMatchers("/api/admin/**").hasAuthority("ROLE_ADMIN")
-					.requestMatchers("/api/auth/**", "/oauth2/**").permitAll()
-					.anyRequest().authenticated()
+				    .anyRequest().permitAll()
 			}
 			.exceptionHandling { it.authenticationEntryPoint(customAuthenticationEntryPoint) }
 			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)

--- a/backend/src/main/java/com/coing/global/exception/doc/ErrorCode.kt
+++ b/backend/src/main/java/com/coing/global/exception/doc/ErrorCode.kt
@@ -51,5 +51,12 @@ enum class ErrorCode(
 	TRADE_NOT_FOUND(HttpStatus.NOT_FOUND, "trade.not.found"),
 
 	// Ticker
-	TICKER_NOT_FOUND(HttpStatus.NOT_FOUND, "ticker.not.found")
+	TICKER_NOT_FOUND(HttpStatus.NOT_FOUND, "ticker.not.found"),
+
+	// Chat
+	MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "message.not.found"),
+	MESSAGE_ALREADY_REPORTED(HttpStatus.CONFLICT, "message.already.reported"),
+	CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "chat.room.not.found"),
+	MESSAGE_REPORT_FAILED(HttpStatus.BAD_REQUEST, "message.report.failed"),
+	REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "report.not.found")
 }

--- a/backend/src/test/java/com/coing/domain/bookmark/service/BookmarkServiceTest.kt
+++ b/backend/src/test/java/com/coing/domain/bookmark/service/BookmarkServiceTest.kt
@@ -6,7 +6,7 @@ import com.coing.domain.bookmark.repository.BookmarkRepository
 import com.coing.domain.coin.market.entity.Market
 import com.coing.domain.coin.market.repository.MarketRepository
 import com.coing.domain.user.dto.CustomUserPrincipal
-import com.coing.domain.user.entity.Authority.USER
+import com.coing.domain.user.entity.Authority
 import com.coing.domain.user.entity.Provider.EMAIL
 import com.coing.domain.user.entity.User
 import com.coing.domain.user.repository.UserRepository
@@ -126,7 +126,7 @@ class BookmarkServiceTest {
             name = name,
             email = email,
             password = "1234",
-            authority = USER,
+            authority = Authority.ROLE_USER,
             verified = true,
             provider = EMAIL
         )

--- a/backend/src/test/java/com/coing/domain/chat/controller/ChatControllerTest.kt
+++ b/backend/src/test/java/com/coing/domain/chat/controller/ChatControllerTest.kt
@@ -13,11 +13,13 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
 
 @SpringBootTest(classes = [CoingApplication::class])
 @AutoConfigureMockMvc
@@ -26,7 +28,7 @@ class ChatControllerIntegrationTest @Autowired constructor(
     val mockMvc: MockMvc,
     val objectMapper: ObjectMapper,
     val chatRoomRepository: ChatRoomRepository,
-    val marketRepository: MarketRepository,  // Market을 영속화하기 위한 Repository
+    val marketRepository: MarketRepository,
     val chatService: ChatService
 ) {
 
@@ -37,34 +39,35 @@ class ChatControllerIntegrationTest @Autowired constructor(
         // 테스트용 Market 엔티티 생성 및 영속화
         val market = Market(code = "KRW-BTC", koreanName = "비트코인", englishName = "Bitcoin")
         val savedMarket = marketRepository.save(market)
-
         // 영속화된 Market을 이용하여 채팅방 생성
-        testChatRoom = ChatRoom(
-            market = savedMarket,
-            name = "테스트 채팅방"
-        )
+        testChatRoom = ChatRoom(market = savedMarket, name = "테스트 채팅방")
         testChatRoom = chatRoomRepository.save(testChatRoom)
 
-        // 캐시에 저장된 메시지 추가: ChatService.sendMessage()를 사용
+        // 테스트용 송신자 (User) 생성
         val sender = com.coing.domain.user.entity.User(
-            id = java.util.UUID.randomUUID(),
-            name = "Alice",
-            email = "alice@example.com",
+            id = UUID.randomUUID(),
+            name = "test",
+            email = "test@example.com",
             password = "encoded",
             provider = com.coing.domain.user.entity.Provider.EMAIL,
             verified = true
         )
+        // 채팅 메시지 전송 (메시지는 캐시에 저장됨)
         chatService.sendMessage(testChatRoom.id!!, sender, "Hello")
         chatService.sendMessage(testChatRoom.id!!, sender, "How are you?")
+
     }
 
     @Test
-    fun `채팅방의 메시지 목록 조회`() {
+    @WithMockUser(username = "testuser", roles = ["USER"])
+    fun `채팅방의 메시지 목록 조회 - 캐시 메시지 조회`() {
         // '/api/chat/rooms/{marketCode}/messages' 엔드포인트 호출
-        mockMvc.perform(get("/api/chat/rooms/KRW-BTC/messages")
-            .contentType(MediaType.APPLICATION_JSON))
+        mockMvc.perform(
+            get("/api/chat/rooms/KRW-BTC/messages")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$[0].sender").exists())
+            .andExpect(jsonPath("$[0].sender").value("test"))
             .andExpect(jsonPath("$[0].content").value("Hello"))
             .andExpect(jsonPath("$[1].content").value("How are you?"))
     }

--- a/backend/src/test/java/com/coing/domain/chat/controller/ChatReportControllerTest.kt
+++ b/backend/src/test/java/com/coing/domain/chat/controller/ChatReportControllerTest.kt
@@ -1,0 +1,136 @@
+package com.coing.domain.chat.controller
+
+import com.coing.domain.chat.entity.ChatMessage
+import com.coing.domain.chat.service.ChatReportService
+import com.coing.domain.chat.service.ChatService
+import com.coing.domain.user.entity.Authority
+import com.coing.domain.user.entity.Provider
+import com.coing.domain.user.entity.User
+import com.coing.util.BasicResponse
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import java.util.*
+
+@WebMvcTest(ChatReportController::class)
+@MockBean(JpaMetamodelMappingContext::class) // JPA 메타모델 초기화 오류 방지
+class ChatReportControllerTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @MockBean
+    lateinit var chatService: ChatService
+
+    @MockBean
+    lateinit var chatReportService: ChatReportService
+
+    // 테스트에서 사용할 도메인 User를 하나 생성하고 재사용합니다.
+    private fun createDummyUser(): User {
+        return User(
+            id = UUID.randomUUID(),
+            name = "TestUser",
+            email = "test@example.com",
+            password = "encodedPassword",
+            authority = Authority.ROLE_USER,
+            verified = true,
+            provider = Provider.EMAIL
+        )
+    }
+
+    // 생성한 User 객체를 기반으로 인증 객체를 생성합니다.
+    private fun createAuthentication(user: User): UsernamePasswordAuthenticationToken {
+        return UsernamePasswordAuthenticationToken(
+            user,
+            "password",
+            listOf(SimpleGrantedAuthority("USER"))
+        )
+    }
+
+    @Test
+    fun `신고 API - 메시지 없음 - 404 반환`() {
+        `when`(chatService.findMessageById(1L)).thenReturn(null)
+
+        // 별도 User 객체는 사용하지 않아도 되며, 여기서는 임의 인증 객체 생성
+        val dummyUser = createDummyUser()
+        val auth = createAuthentication(dummyUser)
+
+        mockMvc.perform(
+            post("/api/chat/messages/1/report")
+                .with(authentication(auth))
+                .with(csrf())
+        )
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.message").value("메시지를 찾을 수 없습니다."))
+    }
+
+    @Test
+    fun `신고 API - 신고 성공 - OK 반환`() {
+        // 신고 성공 케이스도 동일한 User 객체를 사용합니다.
+        val userEntity = createDummyUser()
+        val auth = createAuthentication(userEntity)
+
+        val chatMessage = ChatMessage(
+            id = 1L,
+            chatRoom = null, // 테스트에서는 채팅방 정보는 불필요
+            sender = userEntity,  // 여기서 동일한 userEntity 사용
+            content = "Hello, world!",
+            timestamp = null
+        )
+
+        `when`(chatService.findMessageById(1L)).thenReturn(chatMessage)
+        // 신고 성공 시 리턴값은 사용하지 않으므로 null 반환 (또는 실제 ChatMessageReport 인스턴스 가능)
+        `when`(chatReportService.reportMessage(chatMessage, userEntity)).thenReturn(null)
+
+        mockMvc.perform(
+            post("/api/chat/messages/1/report")
+                .with(authentication(auth))
+                .with(csrf())
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("메시지가 신고되었습니다."))
+    }
+
+    @Test
+    fun `신고 API - 신고 중복 등 예외 발생 - 400 반환`() {
+        // 신고 중복 예외 발생 케이스에서도 동일한 User 객체 사용
+        val userEntity = createDummyUser()
+        val auth = createAuthentication(userEntity)
+
+        val chatMessage = ChatMessage(
+            id = 1L,
+            chatRoom = null,
+            sender = userEntity,  // 동일한 userEntity
+            content = "Hello, world!",
+            timestamp = null
+        )
+
+        `when`(chatService.findMessageById(1L)).thenReturn(chatMessage)
+        `when`(chatReportService.reportMessage(chatMessage, userEntity))
+            .thenThrow(RuntimeException("이미 신고한 메시지입니다."))
+
+        mockMvc.perform(
+            post("/api/chat/messages/1/report")
+                .with(authentication(auth))
+                .with(csrf())
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.message").value("이미 신고한 메시지입니다."))
+    }
+}

--- a/backend/src/test/java/com/coing/domain/user/controller/AdminControllerTest.kt
+++ b/backend/src/test/java/com/coing/domain/user/controller/AdminControllerTest.kt
@@ -1,0 +1,41 @@
+package com.coing.domain.user.controller
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AdminControllerIntegrationTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Test
+    @WithMockUser(roles = ["ADMIN"])
+    fun `관리자 권한으로 신고 메시지 조회 - OK 반환`() {
+        mockMvc.perform(
+            get("/api/admin/reported-messages")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+            // 결과가 JSON 배열임을 확인 (신고 내역 데이터가 없더라도 빈 배열이 반환됩니다)
+            .andExpect(jsonPath("$").isArray)
+    }
+
+    @Test
+    @WithMockUser(roles = ["USER"])
+    fun `일반 사용자 권한으로 관리자 엔드포인트 접근 - Forbidden 반환`() {
+        mockMvc.perform(
+            get("/api/admin/reported-messages")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isForbidden)
+    }
+}

--- a/backend/src/test/java/com/coing/domain/user/controller/UserControllerTest.kt
+++ b/backend/src/test/java/com/coing/domain/user/controller/UserControllerTest.kt
@@ -10,6 +10,7 @@ import com.coing.domain.user.service.AuthTokenService
 import com.coing.domain.user.service.UserService
 import com.coing.domain.user.email.service.EmailVerificationService
 import com.coing.domain.user.email.service.PasswordResetService
+import com.coing.domain.user.entity.Authority
 import com.coing.util.MessageUtil
 import com.fasterxml.jackson.databind.ObjectMapper
 import kotlinx.coroutines.runBlocking
@@ -93,7 +94,8 @@ class UserControllerIntegrationTest {
             id = userId,
             name = "테스트",
             email = "integration@test.com",
-            verified = false
+            verified = false,
+            authority = Authority.ROLE_USER
         )
         val userEntity = User(
             id = userId,
@@ -186,7 +188,8 @@ class UserControllerIntegrationTest {
             id = UUID.randomUUID(),
             name = "테스트",
             email = "integration@test.com",
-            verified = true
+            verified = true,
+            authority = Authority.ROLE_USER
         )
         given(userService.login("integration@test.com", "pass1234!")).willReturn(userResponse)
 

--- a/backend/src/test/java/com/coing/domain/user/service/UserServiceTest.kt
+++ b/backend/src/test/java/com/coing/domain/user/service/UserServiceTest.kt
@@ -72,7 +72,7 @@ internal class UserControllerTest {
     @DisplayName("회원가입 - 성공")
     fun testSignUpSuccess() = runBlocking {
         val signupRequest = UserSignUpRequest("테스트", "test@test.com", "pass1234!", "pass1234!")
-        val userResponse = UserResponse(UUID.randomUUID(), "테스트", "test@test.com", false)
+        val userResponse = UserResponse(UUID.randomUUID(), "테스트", "test@test.com", false, Authority.ROLE_USER)
         `when`(userService.join(signupRequest)).thenReturn(userResponse)
 
         // userService.join() 후, 실제 User 엔티티를 반환하도록 stub 설정
@@ -107,7 +107,7 @@ internal class UserControllerTest {
     fun testVerifyEmailAlreadyVerified() {
         val userId = UUID.randomUUID()
         `when`(authTokenService.parseId("validToken")).thenReturn(userId)
-        val user = User(userId, "테스트", "test@test.com", "dummy", Authority.USER, true)
+        val user = User(userId, "테스트", "test@test.com", "dummy", Authority.ROLE_USER, true)
         `when`(userRepository.findById(userId)).thenReturn(Optional.of(user))
 
         val result: ResponseEntity<*> = userController.verifyEmail("validToken")
@@ -196,7 +196,7 @@ internal class UserControllerTest {
     fun testLoginSuccess() {
         val email = "test@test.com"
         val password = "pass1234!"
-        val userResponse = UserResponse(UUID.randomUUID(), "테스트", email, true)
+        val userResponse = UserResponse(UUID.randomUUID(), "테스트", email,true,  Authority.ROLE_USER)
         `when`(userService.login(email, password)).thenReturn(userResponse)
         doNothing().`when`(response).setHeader(anyString(), anyString())
         val result: ResponseEntity<*> = userController.login(UserLoginRequest(email, password), response)
@@ -214,7 +214,7 @@ internal class UserControllerTest {
         val userId = UUID.randomUUID()
         val claims = mapOf("id" to userId.toString())
         `when`(authTokenService.verifyToken(refreshToken)).thenReturn(claims)
-        val userResponse = UserResponse(userId, "테스트", "test@test.com", true)
+        val userResponse = UserResponse(userId, "테스트", "test@test.com",true, Authority.ROLE_USER)
         `when`(userService.findById(userId)).thenReturn(userResponse)
         doNothing().`when`(response).setHeader(anyString(), anyString())
         val result: ResponseEntity<*> = userController.refreshToken(request, response)
@@ -248,7 +248,7 @@ internal class UserControllerTest {
     @DisplayName("회원 정보 조회 - 성공")
     fun testGetUserInfoSuccess() {
         val principal = CustomUserPrincipal(UUID.randomUUID())
-        val userResponse = UserResponse(principal.id, "테스트", "test@test.com", true)
+        val userResponse = UserResponse(principal.id, "테스트", "test@test.com",true, Authority.ROLE_USER)
         `when`(userService.findById(principal.id)).thenReturn(userResponse)
         val result = userController.getUserInfo(principal) as? ResponseEntity<UserResponse>
             ?: throw IllegalStateException("Expected ResponseEntity<UserResponse>")


### PR DESCRIPTION
## 연관된 이슈

> #41 #37 
> 

## 작업 내용

> DB단에서 authority 1로 변경하면 ROLE_ADMIN으로 변경되게 구현 (멘토님이 말씀하신 것 처럼 root계정 하나만 두면 될 것 같음)
> jwt 토큰에 authority 추가
    - 필터, 토큰 서비스 변경
> AdminController 추가
    -  시큐리티 설정에서 해당 엔드포인트로 접근 시 토큰에 있는 ADMIN 권한 있어야 접근 가능하게 설정
> 채팅 신고 기능 추가 
    - 일단 3회 이상 다른 유저가 신고한 채팅만 DB에 저장되게 했음
    - AdminController에서 조회 엔드포인트 구현
> 기타 수정
    - 변경된 토큰 로직, 유저 엔티티에 따른 코드 수정 

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #41