### PR TITLE
Feat/43  external messaging dependency

### DIFF
--- a/backend/src/main/java/com/coing/domain/coin/common/port/CodeDto.kt
+++ b/backend/src/main/java/com/coing/domain/coin/common/port/CodeDto.kt
@@ -1,0 +1,5 @@
+package com.coing.domain.coin.common.port
+
+interface CodeDto {
+    val code: String
+}

--- a/backend/src/main/java/com/coing/domain/coin/common/port/CoinDataHandler.kt
+++ b/backend/src/main/java/com/coing/domain/coin/common/port/CoinDataHandler.kt
@@ -1,5 +1,5 @@
 package com.coing.domain.coin.common.port
 
-interface DataHandler<T> {
+interface CoinDataHandler<T> {
     fun update(data: T)
 }

--- a/backend/src/main/java/com/coing/domain/coin/common/port/EventPublisher.kt
+++ b/backend/src/main/java/com/coing/domain/coin/common/port/EventPublisher.kt
@@ -1,0 +1,5 @@
+package com.coing.domain.coin.common.port
+
+interface EventPublisher<T> {
+    fun publish(event: T)
+}

--- a/backend/src/main/java/com/coing/domain/coin/orderbook/dto/OrderbookDto.kt
+++ b/backend/src/main/java/com/coing/domain/coin/orderbook/dto/OrderbookDto.kt
@@ -1,11 +1,12 @@
 package com.coing.domain.coin.orderbook.dto
 
+import com.coing.domain.coin.common.port.CodeDto
 import com.coing.domain.coin.orderbook.entity.Orderbook
 import com.coing.domain.coin.orderbook.entity.OrderbookUnit
 
 data class OrderbookDto(
     val type: String,                        // "orderbook"
-    val code: String,                        // 마켓 코드 (ex. KRW-BTC)
+    override val code: String,                        // 마켓 코드 (ex. KRW-BTC)
     val totalAskSize: Double,                // 호가 매도 총 잔량
     val totalBidSize: Double,                // 호가 매수 총 잔량
     val orderbookUnits: List<OrderbookUnit>, // 상세 호가 정보 목록
@@ -15,7 +16,7 @@ data class OrderbookDto(
     val spread: Double,                      // 매도/매수 호가 차이
     val imbalance: Double,                   // 잔량 불균형
     val liquidityDepth: Double               // ±X% 유동성 비율
-) {
+) : CodeDto{
     companion object {
         fun from(orderbook: Orderbook): OrderbookDto = OrderbookDto(
             type = orderbook.type,

--- a/backend/src/main/java/com/coing/domain/coin/orderbook/service/OrderbookService.kt
+++ b/backend/src/main/java/com/coing/domain/coin/orderbook/service/OrderbookService.kt
@@ -1,17 +1,17 @@
 package com.coing.domain.coin.orderbook.service;
 
 import com.coing.domain.coin.common.port.CoinDataHandler
+import com.coing.domain.coin.common.port.EventPublisher
 import com.coing.domain.coin.orderbook.dto.OrderbookDto
 import com.coing.domain.coin.orderbook.entity.Orderbook
 import org.slf4j.LoggerFactory
-import org.springframework.messaging.simp.SimpMessageSendingOperations
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import java.util.concurrent.ConcurrentHashMap
 
 @Service
 class OrderbookService(
-	private val messagingTemplate: SimpMessageSendingOperations
+    private val eventPublisher: EventPublisher<OrderbookDto>
 	) : CoinDataHandler<Orderbook> {
 
 	private val orderbookCache: MutableMap<String, OrderbookDto> = ConcurrentHashMap()
@@ -29,7 +29,7 @@ class OrderbookService(
 		val lastSent = lastSentTime.getOrDefault(market, 0L)
 
 		if (now - lastSent >= THROTTLE_INTERVAL_MS) {
-			messagingTemplate.convertAndSend("/sub/coin/orderbook/$market", dto)
+			eventPublisher.publish(dto)
 			lastSentTime[market] = now
 		}
 	}

--- a/backend/src/main/java/com/coing/domain/coin/orderbook/service/OrderbookService.kt
+++ b/backend/src/main/java/com/coing/domain/coin/orderbook/service/OrderbookService.kt
@@ -1,6 +1,6 @@
 package com.coing.domain.coin.orderbook.service;
 
-import com.coing.domain.coin.common.port.DataHandler
+import com.coing.domain.coin.common.port.CoinDataHandler
 import com.coing.domain.coin.orderbook.dto.OrderbookDto
 import com.coing.domain.coin.orderbook.entity.Orderbook
 import org.slf4j.LoggerFactory
@@ -12,7 +12,7 @@ import java.util.concurrent.ConcurrentHashMap
 @Service
 class OrderbookService(
 	private val messagingTemplate: SimpMessageSendingOperations
-	) : DataHandler<Orderbook> {
+	) : CoinDataHandler<Orderbook> {
 
 	private val orderbookCache: MutableMap<String, OrderbookDto> = ConcurrentHashMap()
 	private val lastSentTime: MutableMap<String, Long> = ConcurrentHashMap()

--- a/backend/src/main/java/com/coing/domain/coin/ticker/dto/TickerDto.kt
+++ b/backend/src/main/java/com/coing/domain/coin/ticker/dto/TickerDto.kt
@@ -2,6 +2,7 @@ package com.coing.domain.coin.ticker.dto
 
 import com.coing.domain.coin.common.enums.AskBid
 import com.coing.domain.coin.common.enums.Change
+import com.coing.domain.coin.common.port.CodeDto
 import com.coing.domain.coin.market.entity.Market
 import com.coing.domain.coin.ticker.entity.Ticker
 import com.coing.domain.coin.ticker.entity.enums.MarketState
@@ -11,7 +12,7 @@ import java.time.LocalTime
 
 data class TickerDto(
     val type: String,             // 데이터 타입 (예: "ticker")
-    val code: String,             // 마켓 코드 (예: "KRW-BTC")
+    override val code: String,             // 마켓 코드 (예: "KRW-BTC")
     val koreanName: String,       // 한글 이름
     val englishName: String,      // 영어 이름
     val openingPrice: Double,     // 시가
@@ -48,7 +49,7 @@ data class TickerDto(
     val highBreakout: Boolean,   // 52주 최고가 갱신 여부
     val lowBreakout: Boolean     // 52주 최저가 갱신 여부
     // val oneMinuteRate: Double? // 주석 처리됨
-) {
+) : CodeDto {
     companion object {
         fun from(ticker: Ticker, market: Market): TickerDto {
             return TickerDto(

--- a/backend/src/main/java/com/coing/domain/coin/ticker/service/TickerService.kt
+++ b/backend/src/main/java/com/coing/domain/coin/ticker/service/TickerService.kt
@@ -1,6 +1,6 @@
 package com.coing.domain.coin.ticker.service
 
-import com.coing.domain.coin.common.port.DataHandler
+import com.coing.domain.coin.common.port.CoinDataHandler
 import com.coing.domain.coin.market.service.MarketService
 import com.coing.domain.coin.ticker.dto.TickerDto
 import com.coing.domain.coin.ticker.entity.Ticker
@@ -16,7 +16,7 @@ class TickerService(
     private val messageUtil: MessageUtil,
     private val marketService: MarketService,
     private val messagingTemplate: SimpMessageSendingOperations,
-) : DataHandler<Ticker> {
+) : CoinDataHandler<Ticker> {
     private val tickerCache = ConcurrentHashMap<String, TickerDto>()
     private val lastSentTime = ConcurrentHashMap<String, Long>()
     private val throttleIntervalMs = 200L

--- a/backend/src/main/java/com/coing/domain/coin/trade/dto/TradeDto.kt
+++ b/backend/src/main/java/com/coing/domain/coin/trade/dto/TradeDto.kt
@@ -2,13 +2,14 @@ package com.coing.domain.coin.trade.dto
 
 import com.coing.domain.coin.common.enums.AskBid
 import com.coing.domain.coin.common.enums.Change
+import com.coing.domain.coin.common.port.CodeDto
 import com.coing.domain.coin.trade.entity.Trade
 import java.time.LocalDate
 import java.time.LocalTime
 
 data class TradeDto(
     val type: String,
-    val code: String,
+    override val code: String,
     val tradePrice: Double,
     val tradeVolume: Double,
     val askBid: AskBid,
@@ -27,7 +28,7 @@ data class TradeDto(
     val vwap: Double,
     val averageTradeSize: Double,
     val tradeImpact: Double
-) {
+) : CodeDto {
     companion object {
         fun of(trade: Trade, vwap: Double, averageTradeSize: Double, tradeImpact: Double): TradeDto =
             TradeDto(

--- a/backend/src/main/java/com/coing/domain/coin/trade/service/TradeService.kt
+++ b/backend/src/main/java/com/coing/domain/coin/trade/service/TradeService.kt
@@ -1,13 +1,13 @@
 package com.coing.domain.coin.trade.service
 
 import com.coing.domain.coin.common.port.CoinDataHandler
+import com.coing.domain.coin.common.port.EventPublisher
 import com.coing.domain.coin.trade.dto.TradeDto
 import com.coing.domain.coin.trade.entity.Trade
 import com.coing.global.exception.BusinessException
 import com.coing.util.MessageUtil
 import lombok.extern.slf4j.Slf4j
 import org.springframework.http.HttpStatus
-import org.springframework.messaging.simp.SimpMessageSendingOperations
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import java.util.concurrent.ConcurrentHashMap
@@ -16,7 +16,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 @Service
 @Slf4j
 class TradeService(
-    private val simpMessageSendingOperations: SimpMessageSendingOperations,
+    private val eventPublisher: EventPublisher<TradeDto>,
     private val messageUtil: MessageUtil
 ): CoinDataHandler<Trade> {
 
@@ -72,7 +72,7 @@ class TradeService(
         val lastSent = lastSentTime[market] ?: 0L
 
         if (now - lastSent >= throttleIntervalMs) {
-            simpMessageSendingOperations.convertAndSend("/sub/coin/trade/$market", dto)
+            eventPublisher.publish(dto)
             lastSentTime[market] = now
         }
     }

--- a/backend/src/main/java/com/coing/domain/coin/trade/service/TradeService.kt
+++ b/backend/src/main/java/com/coing/domain/coin/trade/service/TradeService.kt
@@ -1,6 +1,6 @@
 package com.coing.domain.coin.trade.service
 
-import com.coing.domain.coin.common.port.DataHandler
+import com.coing.domain.coin.common.port.CoinDataHandler
 import com.coing.domain.coin.trade.dto.TradeDto
 import com.coing.domain.coin.trade.entity.Trade
 import com.coing.global.exception.BusinessException
@@ -18,7 +18,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 class TradeService(
     private val simpMessageSendingOperations: SimpMessageSendingOperations,
     private val messageUtil: MessageUtil
-): DataHandler<Trade> {
+): CoinDataHandler<Trade> {
 
     private val tradeListCache = ConcurrentHashMap<String, ConcurrentLinkedQueue<TradeDto>>()
     private val vwapCache = ConcurrentHashMap<String, Double>()

--- a/backend/src/main/java/com/coing/infra/messaging/websocket/WebSocketEventPublisherConfig.kt
+++ b/backend/src/main/java/com/coing/infra/messaging/websocket/WebSocketEventPublisherConfig.kt
@@ -1,4 +1,4 @@
-package com.coing.infra.messaging.websocket.config
+package com.coing.infra.messaging.websocket
 
 import com.coing.domain.coin.common.port.EventPublisher
 import com.coing.domain.coin.orderbook.dto.OrderbookDto

--- a/backend/src/main/java/com/coing/infra/messaging/websocket/config/WebSocketEventPublisherConfig.kt
+++ b/backend/src/main/java/com/coing/infra/messaging/websocket/config/WebSocketEventPublisherConfig.kt
@@ -1,0 +1,29 @@
+package com.coing.infra.messaging.websocket.config
+
+import com.coing.domain.coin.common.port.EventPublisher
+import com.coing.domain.coin.orderbook.dto.OrderbookDto
+import com.coing.domain.coin.ticker.dto.TickerDto
+import com.coing.domain.coin.trade.dto.TradeDto
+import com.coing.infra.messaging.websocket.constant.WebSocketSubscriptionTopics
+import com.coing.infra.messaging.websocket.publisher.WebSocketEventPublisher
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.SimpMessageSendingOperations
+
+@Configuration
+class WebSocketEventPublisherConfig {
+    @Bean
+    fun tradeEventPublisher(messagingTemplate: SimpMessageSendingOperations): EventPublisher<TradeDto> {
+        return WebSocketEventPublisher(messagingTemplate, WebSocketSubscriptionTopics.TRADES)
+    }
+
+    @Bean
+    fun tickerEventPublisher(messagingTemplate: SimpMessageSendingOperations): EventPublisher<TickerDto> {
+        return WebSocketEventPublisher(messagingTemplate, WebSocketSubscriptionTopics.TICKERS)
+    }
+
+    @Bean
+    fun orderbookEventPublisher(messagingTemplate: SimpMessageSendingOperations): EventPublisher<OrderbookDto> {
+        return WebSocketEventPublisher(messagingTemplate, WebSocketSubscriptionTopics.ORDERBOOKS)
+    }
+}

--- a/backend/src/main/java/com/coing/infra/messaging/websocket/constant/WebSocketSubscriptionTopics.kt
+++ b/backend/src/main/java/com/coing/infra/messaging/websocket/constant/WebSocketSubscriptionTopics.kt
@@ -1,0 +1,7 @@
+package com.coing.infra.messaging.websocket.constant
+
+object WebSocketSubscriptionTopics {
+    const val TRADES = "/sub/coin/trade"
+    const val ORDERBOOKS = "/sub/coin/orderbook"
+    const val TICKERS = "/sub/coin/ticker"
+}

--- a/backend/src/main/java/com/coing/infra/messaging/websocket/publisher/WebSocketEventPublisher.kt
+++ b/backend/src/main/java/com/coing/infra/messaging/websocket/publisher/WebSocketEventPublisher.kt
@@ -1,0 +1,16 @@
+package com.coing.infra.messaging.websocket.publisher
+
+import com.coing.domain.coin.common.port.EventPublisher
+import com.coing.domain.coin.common.port.CodeDto
+import org.springframework.messaging.simp.SimpMessageSendingOperations
+
+class WebSocketEventPublisher<T>(
+    private val messagingTemplate: SimpMessageSendingOperations,
+    private val destinationPrefix: String
+): EventPublisher<T> where T : CodeDto {
+
+    override fun publish(event: T) {
+        val destination = "$destinationPrefix/${event.code}"
+        messagingTemplate.convertAndSend(destination, event)
+    }
+}

--- a/backend/src/main/java/com/coing/infra/upbit/adapter/UpbitDataService.kt
+++ b/backend/src/main/java/com/coing/infra/upbit/adapter/UpbitDataService.kt
@@ -1,6 +1,6 @@
 package com.coing.infra.upbit.adapter
 
-import com.coing.domain.coin.common.port.DataHandler
+import com.coing.domain.coin.common.port.CoinDataHandler
 import com.coing.domain.coin.orderbook.entity.Orderbook
 import com.coing.domain.coin.ticker.entity.Ticker
 import com.coing.domain.coin.trade.entity.Trade
@@ -18,25 +18,25 @@ import org.springframework.stereotype.Service
  */
 @Service
 class UpbitDataService(
-    private val orderbookDataHandler: DataHandler<Orderbook>,
-    private val tickerDataHandler: DataHandler<Ticker>,
-    private val tradeDataHandler: DataHandler<Trade>,
+    private val orderbookCoinDataHandler: CoinDataHandler<Orderbook>,
+    private val tickerCoinDataHandler: CoinDataHandler<Ticker>,
+    private val tradeCoinDataHandler: CoinDataHandler<Trade>,
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
 
     fun handleOrderbookEvent(dto: UpbitWebSocketOrderbookDto) {
         val orderbook = dto.toEntity()
-        orderbookDataHandler.update(orderbook)
+        orderbookCoinDataHandler.update(orderbook)
     }
 
     fun handleTickerEvent(dto: UpbitWebSocketTickerDto) {
         // double oneMinuteRate = tickerService.calculateOneMinuteRate(dto.getCode(), dto.getTradePrice());
         val ticker: Ticker = dto.toEntity()
-        tickerDataHandler.update(ticker)
+        tickerCoinDataHandler.update(ticker)
     }
 
     fun handleTradeEvent(dto: UpbitWebSocketTradeDto) {
         val trade = dto.toEntity()
-        tradeDataHandler.update(trade)
+        tradeCoinDataHandler.update(trade)
     }
 }

--- a/backend/src/test/java/com/coing/domain/coin/ticker/service/TickerServiceTest.kt
+++ b/backend/src/test/java/com/coing/domain/coin/ticker/service/TickerServiceTest.kt
@@ -2,6 +2,7 @@ package com.coing.domain.coin.ticker.service
 
 import com.coing.domain.coin.common.enums.AskBid
 import com.coing.domain.coin.common.enums.Change
+import com.coing.domain.coin.common.port.EventPublisher
 import com.coing.domain.coin.market.entity.Market
 import com.coing.domain.coin.market.service.MarketService
 import com.coing.domain.coin.ticker.dto.TickerDto
@@ -10,19 +11,16 @@ import com.coing.domain.coin.ticker.entity.enums.MarketState
 import com.coing.domain.coin.ticker.entity.enums.MarketWarning
 import com.coing.global.exception.BusinessException
 import com.coing.util.MessageUtil
-import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentCaptor
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.messaging.simp.SimpMessageSendingOperations
 import java.lang.reflect.Field
 import java.time.LocalDate
 import java.time.LocalTime
@@ -31,7 +29,7 @@ import java.time.LocalTime
 class TickerServiceTest {
 
     @Mock
-    private lateinit var simpMessageSendingOperations: SimpMessageSendingOperations
+    private lateinit var tickerPublisher: EventPublisher<TickerDto>
 
     @Mock
     private lateinit var messageUtil: MessageUtil
@@ -145,15 +143,7 @@ class TickerServiceTest {
 
         tickerService.publish(dto)
 
-        val captor = ArgumentCaptor.forClass(TickerDto::class.java)
-        verify(simpMessageSendingOperations, times(1))
-            .convertAndSend(eq("/sub/coin/ticker/KRW-BTC"), captor.capture())
-
-        val sentDto = captor.value
-        val actualValue = mapper.writeValueAsString(sentDto)
-        val jsonNode: JsonNode = mapper.readTree(actualValue)
-
-        assertEquals("ticker", jsonNode["type"].asText())
-        assertEquals("KRW-BTC", jsonNode["code"].asText())
+        verify(tickerPublisher, times(1))
+            .publish(dto)
     }
 }

--- a/backend/src/test/java/com/coing/domain/coin/trade/service/TradeServiceTest.kt
+++ b/backend/src/test/java/com/coing/domain/coin/trade/service/TradeServiceTest.kt
@@ -2,6 +2,7 @@ package com.coing.domain.coin.trade.service
 
 import com.coing.domain.coin.common.enums.AskBid.ASK
 import com.coing.domain.coin.common.enums.Change.EVEN
+import com.coing.domain.coin.common.port.EventPublisher
 import com.coing.domain.coin.trade.dto.TradeDto
 import com.coing.domain.coin.trade.entity.Trade
 import com.coing.global.exception.BusinessException
@@ -15,7 +16,6 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.mockito.junit.jupiter.MockitoExtension
-import org.springframework.messaging.simp.SimpMessageSendingOperations
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -23,7 +23,7 @@ import java.time.LocalTime
 class TradeServiceTest {
 
     @Mock
-    lateinit var simpMessageSendingOperations: SimpMessageSendingOperations
+    lateinit var tradePublisher: EventPublisher<TradeDto>
 
     @Mock
     lateinit var messageUtil: MessageUtil
@@ -96,7 +96,7 @@ class TradeServiceTest {
         tradeService.publish(dto)
 
         // then
-        verify(simpMessageSendingOperations, times(1))
-            .convertAndSend(eq("/sub/coin/trade/KRW-BTC"), any(TradeDto::class.java))
+        verify(tradePublisher, times(1))
+            .publish(dto)
     }
 }


### PR DESCRIPTION
## 연관된 이슈

> ex) #이슈번호, #이슈번호
> #43 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
>  기존 코인 도메인 서비스(Trade, Orderbook, Ticker 등)에서 SimpMessageSendingOperations를 직접 호출하여 클라이언트로 메시지를 전송하던 구조를 개선했습니다. -> infra.messaging.websocket으로 코드 분리

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #43