### PR TITLE
Feat/65 naver api modify

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
 
     implementation("com.google.firebase:firebase-admin:9.4.3")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
+    implementation("org.springframework.retry:spring-retry")
 }
 
 tasks.named<Test>("test") {

--- a/backend/src/main/java/com/coing/CoingApplication.kt
+++ b/backend/src/main/java/com/coing/CoingApplication.kt
@@ -5,12 +5,14 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.retry.annotation.EnableRetry
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @SecurityScheme(name = "bearerAuth", type = SecuritySchemeType.HTTP, scheme = "bearer", bearerFormat = "JWT")
 @SpringBootApplication
 @EnableScheduling
 @EnableJpaAuditing
+@EnableRetry
 
 class CoingApplication
 

--- a/backend/src/main/java/com/coing/domain/news/controller/NewsController.kt
+++ b/backend/src/main/java/com/coing/domain/news/controller/NewsController.kt
@@ -3,7 +3,6 @@ package com.coing.domain.news.controller
 import com.coing.domain.news.service.NewsService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -29,7 +28,13 @@ class NewsController(
 		@RequestParam(name = "sort", defaultValue = "sim") sort: String,
 		@RequestParam(name = "format", defaultValue = "json") format: String
 	): ResponseEntity<String> {
-		val result = newsService.searchNewsByMarketCode(marketCode, display, start, sort, format)
-		return ResponseEntity.ok(result)
+		return try {
+			val result = newsService.searchNewsByMarketCode(marketCode, display, start, sort, format)
+			ResponseEntity.ok(result)
+		} catch (ex: Exception) {
+			// 로깅 등 추가 작업 후 사용자에게 에러 메시지를 응답합니다.
+			ResponseEntity.status(503)
+				.body("{\"error\": \"뉴스 서비스를 불러올 수 없습니다. 잠시 후 다시 시도해 주세요.\"}")
+		}
 	}
 }

--- a/backend/src/main/java/com/coing/domain/news/service/NewsService.kt
+++ b/backend/src/main/java/com/coing/domain/news/service/NewsService.kt
@@ -1,19 +1,22 @@
 package com.coing.domain.news.service
 
 import com.coing.domain.coin.market.repository.MarketRepository
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Recover
+import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Service
+import org.springframework.context.annotation.Lazy
 import java.io.BufferedReader
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URI
-import java.net.URL
 import java.net.URLEncoder
-import java.util.NoSuchElementException
 
 @Service
-class NewsService(
+open class NewsService(
 	private val marketRepository: MarketRepository
 ) {
 
@@ -23,10 +26,16 @@ class NewsService(
 	@Value("\${naver.client.secret}")
 	private lateinit var clientSecret: String
 
+	// 자기 자신을 @Lazy로 주입받아 프록시를 통한 호출을 보장합니다.
+	@Autowired
+	@Lazy
+	private lateinit var self: NewsService
+
 	/**
-	 * 마켓 코드를 받아서 해당 마켓의 한국어 이름을 쿼리로 사용해 뉴스 검색 API 호출
+	 * 마켓 코드에 해당하는 마켓의 한국 이름을 검색어로 뉴스 조회.
+	 * 내부에서 self를 통해 @Retryable이 적용된 searchNews 메서드를 호출합니다.
 	 */
-	fun searchNewsByMarketCode(
+	open fun searchNewsByMarketCode(
 		marketCode: String,
 		display: Int,
 		start: Int,
@@ -35,15 +44,20 @@ class NewsService(
 	): String {
 		val market = marketRepository.findByCode(marketCode)
 			?: throw NoSuchElementException("Market not found for code: $marketCode")
-
 		val query = market.koreanName
-		return searchNews(query, display, start, sort, format)
+		// 자기 자신(self)을 통해 호출함으로써 프록시를 경유하게 됩니다.
+		return self.searchNews(query, display, start, sort, format)
 	}
 
 	/**
-	 * 네이버 뉴스 검색 API 호출
+	 * 뉴스 검색 API 호출 (리트라이 대상)
 	 */
-	fun searchNews(
+	@Retryable(
+		value = [RuntimeException::class],
+		maxAttempts = 3,
+		backoff = Backoff(delay = 2000)
+	)
+	open fun searchNews(
 		query: String,
 		display: Int,
 		start: Int,
@@ -55,38 +69,53 @@ class NewsService(
 		} catch (e: Exception) {
 			throw RuntimeException("검색어 인코딩 실패", e)
 		}
-
+		// 실제 서비스에서는 URL이 올바르게 구성되어야 하지만, 오류 검증을 위해 일부러 잘못된 URL을 넣어 재시도 흐름을 테스트할 수 있습니다.
 		val apiURL = "https://openapi.naver.com/v1/search/news.$format" +
 				"?query=$encodedQuery&display=$display&start=$start&sort=$sort"
-
 		val requestHeaders = mapOf(
 			"X-Naver-Client-Id" to clientId,
 			"X-Naver-Client-Secret" to clientSecret
 		)
-
-		return get(apiURL, requestHeaders)
+		return executeGet(apiURL, requestHeaders)
 	}
 
-	private fun get(apiUrl: String, requestHeaders: Map<String, String>): String {
+	/**
+	 * HTTP GET 요청을 실행합니다.
+	 * HTTP_OK(200)가 아닌 응답이면 예외를 발생시켜 리트라이 로직을 트리거합니다.
+	 */
+	open fun executeGet(apiUrl: String, requestHeaders: Map<String, String>): String {
 		val connection = connect(apiUrl)
 		return try {
 			connection.requestMethod = "GET"
 			requestHeaders.forEach { (key, value) ->
 				connection.setRequestProperty(key, value)
 			}
-
-			val stream = if (connection.responseCode == HttpURLConnection.HTTP_OK) {
-				connection.inputStream
-			} else {
-				connection.errorStream
+			// HTTP 상태 코드가 200이 아니면 예외 발생
+			if (connection.responseCode != HttpURLConnection.HTTP_OK) {
+				throw RuntimeException("HTTP error! Status: ${connection.responseCode}")
 			}
-
+			val stream = connection.inputStream
 			readBody(stream)
 		} catch (e: Exception) {
 			throw RuntimeException("API 요청과 응답 실패", e)
 		} finally {
 			connection.disconnect()
 		}
+	}
+
+	/**
+	 *  최대 시도 후에도 실패 시 @Recover 메서드가 호출되어 지정된 에러 메시지를 반환합니다.
+	 */
+	@Recover
+	open fun recover(
+		e: RuntimeException,
+		query: String,
+		display: Int,
+		start: Int,
+		sort: String,
+		format: String
+	): String {
+		return "{\"error\": \"뉴스 서비스를 현재 이용할 수 없습니다. 잠시 후 다시 시도해 주세요.\"}"
 	}
 
 	private fun connect(apiUrl: String): HttpURLConnection {
@@ -99,12 +128,13 @@ class NewsService(
 	}
 
 	private fun readBody(body: InputStream): String {
-		val streamReader = InputStreamReader(body)
-		BufferedReader(streamReader).use { lineReader ->
-			return buildString {
-				var line: String?
-				while (lineReader.readLine().also { line = it } != null) {
-					append(line)
+		InputStreamReader(body).use { streamReader ->
+			BufferedReader(streamReader).use { lineReader ->
+				return buildString {
+					var line: String?
+					while (lineReader.readLine().also { line = it } != null) {
+						append(line)
+					}
 				}
 			}
 		}

--- a/backend/src/test/java/com/coing/domain/news/controller/NewsControllerTest.kt
+++ b/backend/src/test/java/com/coing/domain/news/controller/NewsControllerTest.kt
@@ -24,6 +24,7 @@ class NewsControllerTest {
     @Autowired
     lateinit var objectMapper: ObjectMapper
 
+    // NewsService를 목(mock) 객체로 주입
     @MockitoBean
     lateinit var newsService: NewsService
 
@@ -40,7 +41,7 @@ class NewsControllerTest {
         given(newsService.searchNewsByMarketCode(marketCode, display, start, sort, format))
             .willReturn(sampleNewsJson)
 
-        // when & then
+        // when & then: API 호출 시 올바른 JSON이 반환되는지 확인
         mockMvc.get("/api/news") {
             param("market", marketCode)
             param("display", display.toString())

--- a/backend/src/test/java/com/coing/domain/news/service/NewsServiceTest.kt
+++ b/backend/src/test/java/com/coing/domain/news/service/NewsServiceTest.kt
@@ -6,17 +6,27 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.anyMap
+import org.mockito.Mockito.anyString
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.SpyBean
 
 @SpringBootTest
 class NewsServiceTest @Autowired constructor(
+    @SpyBean
     val newsService: NewsService,
     val marketRepository: MarketRepository
 ) {
 
     @BeforeEach
     fun setup() {
+        // 테스트를 위해 KRW-BTC 마켓이 없으면 미리 생성
         if (!marketRepository.findById("KRW-BTC").isPresent) {
             val market = Market(
                 code = "KRW-BTC",
@@ -36,8 +46,44 @@ class NewsServiceTest @Autowired constructor(
         val format = "json"
 
         val result = newsService.searchNewsByMarketCode(marketCode, display, start, sort, format)
-        // 결과가 null이 아니며, 간단히 특정 키워드가 포함되었는지 확인 (구현에 따라 적절히 변경)
+        // 결과가 null이 아니며, 간단히 특정 키워드 (예제에선 "news")가 포함되었는지 확인합니다.
         assertNotNull(result)
         assertTrue(result.contains("news"), "응답에 news 키워드가 포함되어야 합니다.")
+    }
+
+    @Test
+    fun `리트라이 로직 테스트 - executeGet 실패 후 최종 성공`() {
+        // 시뮬레이션:
+        // 첫 번째 호출: 예외 발생 ("Simulated Failure 1")
+        // 두 번째 호출: 예외 발생 ("Simulated Failure 2")
+        // 세 번째 호출: 성공 응답 반환
+        doThrow(RuntimeException("Simulated Failure 1"))
+            .doThrow(RuntimeException("Simulated Failure 2"))
+            .doReturn("{\"news\": \"리트라이 테스트 성공\"}")
+            .`when`(newsService).executeGet(anyString(), anyMap())
+
+        val result = newsService.searchNews("리트라이 테스트", 10, 1, "sim", "json")
+        assertNotNull(result)
+        assertTrue(result.contains("리트라이 테스트 성공"), "리트라이 후 성공한 결과여야 합니다.")
+        // executeGet()가 세 번 호출되었음을 확인
+        verify(newsService, times(3)).executeGet(anyString(), anyMap())
+    }
+
+    @Test
+    fun `리커버 로직 테스트 - 모든 호출 실패 시 recover 메시지 반환`() {
+        // 시뮬레이션:
+        // 모든 호출에서 예외를 발생시켜 @Recover가 호출되도록 함
+        doThrow(RuntimeException("Simulated Failure"))
+            .`when`(newsService).executeGet(anyString(), anyMap())
+
+        val result = newsService.searchNews("리커버 테스트", 10, 1, "sim", "json")
+        assertNotNull(result)
+        // recover 메서드에서 정의한 에러 메시지가 포함되어 있는지 확인
+        assertTrue(
+            result.contains("뉴스 서비스를 현재 이용할 수 없습니다"),
+            "모든 호출 실패 시 recover 메시지가 반환되어야 합니다."
+        )
+        // 최대 3번 호출되었음을 확인 (실패 후 recover 호출)
+        verify(newsService, times(3)).executeGet(anyString(), anyMap())
     }
 }

--- a/frontend/src/app/coin/components/NewsList.tsx
+++ b/frontend/src/app/coin/components/NewsList.tsx
@@ -45,50 +45,64 @@ export default function NewsList({ news: initialNews }: NewsListProps) {
     <div className="bg-card rounded-lg shadow-sm overflow-hidden">
       <div className="p-4 border-b border-muted flex justify-between items-center">
         <h2 className="text-lg font-semibold">뉴스</h2>
-        <button onClick={refreshNews} className="px-3 py-1 text-sm border rounded hover:bg-muted">
+        <button
+          onClick={refreshNews}
+          className="px-3 py-1 text-sm border rounded hover:bg-muted"
+        >
           새로고침
         </button>
       </div>
 
       <div className="overflow-y-auto max-h-[400px]">
-        <ul className="divide-y divide-muted">
-          {currentNews.map((item, index) => (
-            <li key={item.id || index} className="p-4 hover:bg-muted">
-              <a href={item.url} target="_blank" rel="noopener noreferrer" className="block">
-                <h3 className="font-medium mb-1" dangerouslySetInnerHTML={{ __html: item.title }} />
-                <p
-                  className="text-sm text-secondary mb-2"
-                  dangerouslySetInnerHTML={{ __html: item.summary }}
-                />
-                <div className="flex justify-between text-xs text-primary">
-                  <span>{item.source}</span>
-                  <span>{formatDate(item.publishedAt)}</span>
-                </div>
-              </a>
-            </li>
-          ))}
-        </ul>
+        {news.length > 0 ? (
+          <ul className="divide-y divide-muted">
+            {currentNews.map((item, index) => (
+              <li key={item.id || index} className="p-4 hover:bg-muted">
+                <a href={item.url} target="_blank" rel="noopener noreferrer" className="block">
+                  <h3
+                    className="font-medium mb-1"
+                    dangerouslySetInnerHTML={{ __html: item.title }}
+                  />
+                  <p
+                    className="text-sm text-secondary mb-2"
+                    dangerouslySetInnerHTML={{ __html: item.summary }}
+                  />
+                  <div className="flex justify-between text-xs text-primary">
+                    <span>{item.source}</span>
+                    <span>{formatDate(item.publishedAt)}</span>
+                  </div>
+                </a>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="p-4 text-center text-secondary">
+            뉴스 데이터를 불러오는 중입니다. 잠시만 기다려 주세요.
+          </div>
+        )}
       </div>
 
-      <div className="flex justify-center items-center p-4 space-x-4">
-        <button
-          onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
-          disabled={currentPage === 1}
-          className="px-3 py-1 text-sm border rounded disabled:opacity-50"
-        >
-          이전
-        </button>
-        <span className="text-sm">
-          {currentPage} / {totalPages}
-        </span>
-        <button
-          onClick={() => setCurrentPage((prev) => Math.min(prev + 1, totalPages))}
-          disabled={currentPage === totalPages}
-          className="px-3 py-1 text-sm border rounded disabled:opacity-50"
-        >
-          다음
-        </button>
-      </div>
+      {news.length > 0 && (
+        <div className="flex justify-center items-center p-4 space-x-4">
+          <button
+            onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
+            disabled={currentPage === 1}
+            className="px-3 py-1 text-sm border rounded disabled:opacity-50"
+          >
+            이전
+          </button>
+          <span className="text-sm">
+            {currentPage} / {totalPages}
+          </span>
+          <button
+            onClick={() => setCurrentPage((prev) => Math.min(prev + 1, totalPages))}
+            disabled={currentPage === totalPages}
+            className="px-3 py-1 text-sm border rounded disabled:opacity-50"
+          >
+            다음
+          </button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 연관된 이슈

> #65 
> 

## 작업 내용

> 뉴스 api에서 데이터를 불러오지 못할 시, Spring의 retry를 사용해 2초 간격으로 최대 3회 다시 불러오는 로직 구현
> 프론트엔드에서 뉴스 데이터를 불러오지 못할 시 안내 문구 띄워주게 변경

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #65