### PR TITLE
feat: enhance chat input handling and message reporting

### DIFF
--- a/frontend/src/app/coin/components/ChatPanel.tsx
+++ b/frontend/src/app/coin/components/ChatPanel.tsx
@@ -5,11 +5,10 @@ import { useWebSocket } from '@/context/WebSocketContext';
 import { Input } from '@/components/ui/input';
 
 interface ChatMessage {
-  // 메시지의 DB 식별자 (백엔드에서 내려줘야 함)
   id?: number;
   sender: string;
   content: string;
-  timestamp: string; // millisecond 단위의 timestamp
+  timestamp: string;
 }
 
 interface ChatPanelProps {
@@ -18,16 +17,15 @@ interface ChatPanelProps {
 
 const ChatPanel: React.FC<ChatPanelProps> = ({ marketCode }) => {
   const { chatMessages, updateSubscriptions, publishMessage } = useWebSocket();
-  const [input, setInput] = useState<string>('');
+  const [input, setInput] = useState('');
+  const [isComposing, setIsComposing] = useState(false);
   const [cachedMessages, setCachedMessages] = useState<ChatMessage[]>([]);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  // marketCode가 바뀔 때마다 채팅 구독 업데이트
   useEffect(() => {
     updateSubscriptions([{ type: 'chat', markets: [marketCode] }]);
   }, [marketCode]);
 
-  // (1) 초기 마운트 시 + marketCode 변경 시, 백엔드에서 캐시된 메시지 로드
   useEffect(() => {
     const loadCachedMessages = async () => {
       try {
@@ -37,8 +35,6 @@ const ChatPanel: React.FC<ChatPanelProps> = ({ marketCode }) => {
         if (res.ok) {
           const data = await res.json();
           setCachedMessages(data);
-        } else {
-          console.error('캐시된 채팅 기록 불러오기 실패');
         }
       } catch (error) {
         console.error('채팅 기록 불러오기 오류:', error);
@@ -47,24 +43,18 @@ const ChatPanel: React.FC<ChatPanelProps> = ({ marketCode }) => {
     loadCachedMessages();
   }, [marketCode]);
 
-  // (2) chatMessages나 cachedMessages 변경될 때, 자동 스크롤
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [chatMessages[marketCode], cachedMessages]);
 
-  // (3) 메시지 전송 로직
   const sendMessage = () => {
     if (!input.trim()) return;
-
     const token = sessionStorage.getItem('accessToken');
     const message: ChatMessage = {
-      // 백엔드가 sender, timestamp 세팅하므로 여기서는 내용만.
       content: input,
       sender: '',
       timestamp: '',
     };
-
-    // 토큰이 있다면 Authorization 헤더에 넣어 전송
     publishMessage(
       `/app/chat/${marketCode}`,
       JSON.stringify(message),
@@ -73,51 +63,28 @@ const ChatPanel: React.FC<ChatPanelProps> = ({ marketCode }) => {
     setInput('');
   };
 
-  // (4) Enter 키로 전송
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      sendMessage();
-    }
+    if (e.key === 'Enter') sendMessage();
   };
 
-  // (5) 신고 버튼 클릭 시 API 호출
   const handleReport = async (msg: ChatMessage) => {
-    // messageId가 없으면 신고 불가
-    if (!msg.id) {
-      alert('메시지 식별자가 없습니다. 신고할 수 없습니다.');
-      return;
-    }
-
-    try {
-      // 로그인 토큰 (예: sessionStorage에 저장된 accessToken)
-      const token = sessionStorage.getItem('accessToken');
-      if (!token) {
-        alert('로그인이 필요합니다.');
-        return;
-      }
-
-      const reportUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/chat/messages/${msg.id}/report`;
-      const res = await fetch(reportUrl, {
+    if (!msg.id) return alert('메시지 식별자가 없습니다.');
+    const token = sessionStorage.getItem('accessToken');
+    if (!token) return alert('로그인이 필요합니다.');
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/chat/messages/${msg.id}/report`,
+      {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
         },
-      });
-
-      if (res.ok) {
-        alert('신고가 접수되었습니다.');
-      } else {
-        const data = await res.json().catch(() => null);
-        alert(`신고 실패: ${data?.message || '원인을 알 수 없습니다.'}`);
       }
-    } catch (error) {
-      console.error('신고 API 호출 오류:', error);
-      alert('신고에 실패했습니다.');
-    }
+    );
+    if (res.ok) alert('신고 완료');
+    else alert('신고 실패');
   };
 
-  // (6) 실시간 메시지와 캐시된 메시지를 합치되, 중복 제거
   const realtimeMessages = chatMessages[marketCode] || [];
   const allMessages = Array.from(
     new Map(
@@ -130,18 +97,14 @@ const ChatPanel: React.FC<ChatPanelProps> = ({ marketCode }) => {
 
   return (
     <div className="flex flex-col h-full">
-      {/* 메시지 표시 영역 */}
       <div className="flex-1 overflow-y-auto p-2 border-b border-border">
         {allMessages.map((msg, index) => (
           <div key={index} className="mb-2">
             <strong>{msg.sender}:</strong> {msg.content}
             <div className="text-xs text-muted-foreground">
-              {/* 메시지 발송 시각 */}
               {msg.timestamp
                 ? new Date(parseInt(msg.timestamp)).toLocaleTimeString()
                 : ''}
-
-              {/* 신고 버튼: timestamp 옆 */}
               <button
                 onClick={() => handleReport(msg)}
                 className="ml-2 text-red-500 underline"
@@ -153,15 +116,21 @@ const ChatPanel: React.FC<ChatPanelProps> = ({ marketCode }) => {
         ))}
         <div ref={messagesEndRef} />
       </div>
-
-      {/* 입력창 + 전송 버튼 */}
       <div className="flex items-center p-2 border-t border-border">
         <Input
           type="text"
           placeholder="메시지 입력"
           value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={handleKeyDown}
+          onChange={(e) => {
+            setInput(e.target.value); // 항상 업데이트
+          }}
+          onCompositionStart={() => setIsComposing(true)}
+          onCompositionEnd={() => setIsComposing(false)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !isComposing) {
+              sendMessage();
+            }
+          }}
           className="flex-1 mr-2"
         />
         <button


### PR DESCRIPTION
## 연관된 이슈

> #71 
> 

## 작업 내용

> 
macOS 환경에서 한글을 입력할 때, 입력한 마지막 글자가 두 번 반복되는 현상
이 문제는 Windows에서는 발생하지 않으며, macOS의 IME(입력기) 이벤트 처리 방식 차이로 인해 발생

한글 입력 중에는 브라우저가 compositionstart, compositionupdate, compositionend 이벤트를 발생시킵니다.
기존 코드에서는 onChange에서 입력값을 즉시 반영하고 있었고, compositionEnd 시점에서도 또 한 번 입력값이 반영되어 중복 입력이 발생했습니다.

isComposing이라는 상태를 추가하여 한글 조합 중인지 여부를 판단하게 했습니다.
onChange에서는 항상 입력값을 반영하되, compositionEnd에서는 상태만 바꾸고 setInput()을 중복 호출하지 않도록 수정했습니다.
또한 Enter 키 입력 시, isComposing === false일 때만 메시지를 전송하도록 수정했습니다.

> 

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #71