### PR TITLE
Feat/77 separate quit

### DIFF
--- a/backend/src/main/java/com/coing/domain/user/controller/UserController.kt
+++ b/backend/src/main/java/com/coing/domain/user/controller/UserController.kt
@@ -197,7 +197,7 @@ class UserController(
         if (principal == null) {
             throw BusinessException(messageUtil.resolveMessage("empty.token.provided"), HttpStatus.FORBIDDEN, "")
         }
-        val user: UserResponse = userService.findById(principal.id)
+        val user: UserInfoResponse = userService.getUserInfoById(principal.id)
         return ResponseEntity.ok(user)
     }
 

--- a/backend/src/main/java/com/coing/domain/user/controller/dto/UserInfoResponse.kt
+++ b/backend/src/main/java/com/coing/domain/user/controller/dto/UserInfoResponse.kt
@@ -1,0 +1,23 @@
+package com.coing.domain.user.controller.dto
+
+import com.coing.domain.user.entity.Authority
+import com.coing.domain.user.entity.Provider
+import com.coing.domain.user.entity.User
+
+data class UserInfoResponse(
+    val name: String,
+    val email: String,
+    val authority: Authority = Authority.ROLE_USER,
+    val provider: Provider = Provider.EMAIL
+) {
+    companion object {
+        fun from(user: User): UserInfoResponse {
+            return UserInfoResponse(
+                name = user.name,
+                email = user.email,
+                authority = user.authority ?: Authority.ROLE_USER,
+                provider = user.provider
+            )
+        }
+    }
+}

--- a/backend/src/main/java/com/coing/domain/user/service/UserService.kt
+++ b/backend/src/main/java/com/coing/domain/user/service/UserService.kt
@@ -1,5 +1,6 @@
 package com.coing.domain.user.service
 
+import com.coing.domain.user.controller.dto.UserInfoResponse
 import com.coing.domain.user.controller.dto.UserResponse
 import com.coing.domain.user.controller.dto.UserSignUpRequest
 import com.coing.domain.user.email.service.EmailVerificationService
@@ -118,6 +119,20 @@ class UserService(
     fun findById(id: UUID): UserResponse {
         return userRepository.findById(id)
             .map { UserResponse.from(it) }
+            .orElseThrow {
+                BusinessException(
+                    messageUtil.resolveMessage("member.not.found"),
+                    HttpStatus.BAD_REQUEST,
+                    ""
+                )
+            }
+    }
+
+    // 사용자 정보
+    @Transactional(readOnly = true)
+    fun getUserInfoById(id: UUID): UserInfoResponse {
+        return userRepository.findById(id)
+            .map { UserInfoResponse.from(it) }
             .orElseThrow {
                 BusinessException(
                     messageUtil.resolveMessage("member.not.found"),

--- a/frontend/src/app/user/info/page.tsx
+++ b/frontend/src/app/user/info/page.tsx
@@ -89,84 +89,93 @@ export default function UserInfoPage() {
             <p className="mt-1 text-lg">{user.email}</p>
           </div>
         </div>
-        <div className="mt-8">
-          <label
-            htmlFor="password"
-            className="block text-sm font-semibold text-muted-foreground mb-2"
-          >
-            회원 탈퇴를 위해 비밀번호 입력
-          </label>
-          <div className="relative mt-2">
-            <Lock className="absolute left-3 top-2.5 h-4 w-4 text-primary" />
-            <Input
-              id="password"
-              type="password"
-              placeholder="비밀번호를 입력하세요"
-              value={password}
-              required
-              className="border border-input pl-10 placeholder:text-primary bg-background"
-              onChange={(e) => setPassword(e.target.value)}
-            />
+        {/* 이메일 회원 탈퇴 (비밀번호 필요) */}
+        {user.provider === 'EMAIL' && (
+          <>
+            <div className="mt-8">
+              <label
+                htmlFor="password"
+                className="block text-sm font-semibold text-muted-foreground mb-2"
+              >
+                회원 탈퇴를 위해 비밀번호 입력
+              </label>
+              <div className="relative mt-2">
+                <Lock className="absolute left-3 top-2.5 h-4 w-4 text-primary" />
+                <Input
+                  id="password"
+                  type="password"
+                  placeholder="비밀번호를 입력하세요"
+                  value={password}
+                  required
+                  className="border border-input pl-10 placeholder:text-primary bg-background"
+                  onChange={(e) => setPassword(e.target.value)}
+                />
+              </div>
+            </div>
+            <div className="mt-6 flex flex-col gap-4">
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button
+                    disabled={loading}
+                    className="w-full py-3 bg-destructive hover:bg-destructive cursor-pointer"
+                  >
+                    {loading ? '처리 중...' : '회원 탈퇴'}
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>회원 탈퇴 확인</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      정말 회원 탈퇴 하시겠습니까? 이 작업은 복구할 수 없습니다.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel className="cursor-pointer">취소</AlertDialogCancel>
+                    <AlertDialogAction
+                      className="bg-destructive hover:bg-destructive cursor-pointer"
+                      onClick={handleSignOut}
+                    >
+                      탈퇴
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </div>
+          </>
+        )}
+
+        {/* 소셜 회원 탈퇴 */}
+        {user.provider === 'KAKAO' && (
+          <div className="mt-6 flex flex-col gap-4">
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  disabled={loading}
+                  className="w-full py-3 bg-destructive hover:bg-destructive cursor-pointer"
+                >
+                  {loading ? '처리 중...' : '소셜 회원 탈퇴'}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>회원 탈퇴 확인</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    정말 회원 탈퇴 하시겠습니까? 이 작업은 복구할 수 없습니다.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel className="cursor-pointer">취소</AlertDialogCancel>
+                  <AlertDialogAction
+                    className="bg-destructive hover:bg-destructive cursor-pointer"
+                    onClick={handleKakaoSignOut}
+                  >
+                    탈퇴
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
-        </div>
-        <div className="mt-6 flex flex-col gap-4">
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button
-                disabled={loading}
-                className="w-full py-3 bg-destructive hover:bg-destructive cursor-pointer"
-              >
-                {loading ? '처리 중...' : '회원 탈퇴'}
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>회원 탈퇴 확인</AlertDialogTitle>
-                <AlertDialogDescription>
-                  정말 회원 탈퇴 하시겠습니까? 이 작업은 복구할 수 없습니다.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel className="cursor-pointer">취소</AlertDialogCancel>
-                <AlertDialogAction
-                  className="bg-destructive hover:bg-destructive cursor-pointer"
-                  onClick={handleSignOut}
-                >
-                  탈퇴
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        </div>
-        <div className="mt-6 flex flex-col gap-4">
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button
-                disabled={loading}
-                className="w-full py-3 bg-destructive hover:bg-destructive cursor-pointer"
-              >
-                {loading ? '처리 중...' : '소셜 회원 탈퇴'}
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>회원 탈퇴 확인</AlertDialogTitle>
-                <AlertDialogDescription>
-                  정말 회원 탈퇴 하시겠습니까? 이 작업은 복구할 수 없습니다.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel className="cursor-pointer">취소</AlertDialogCancel>
-                <AlertDialogAction
-                  className="bg-destructive hover:bg-destructive cursor-pointer"
-                  onClick={handleKakaoSignOut}
-                >
-                  탈퇴
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        </div>
+        )}
       </div>
     </RequireAuthenticated>
   );

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -117,7 +117,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         if (res.ok) {
           const data = await res.json();
           // 백엔드에서 반환하는 데이터에 authority 값도 포함되어 있다고 가정합니다.
-          setUser({ name: data.name, email: data.email, authority: data.authority });
+          setUser({ name: data.name, email: data.email, authority: data.authority, provider: data.provider });
         } else {
           setUser(defaultState);
         }

--- a/frontend/src/store/user.store.ts
+++ b/frontend/src/store/user.store.ts
@@ -4,6 +4,7 @@ interface UserProfile {
   name: string;
   email: string;
   authority: string; // 추가: 사용자 권한 (예: 'ROLE_ADMIN', 'ROLE_USER')
+  provider: string; // 회원가입 경로 (예: 'EMAIL', 'KAKAO')
 }
 
 interface UserState {
@@ -18,7 +19,8 @@ const storedUser =
 export const defaultState: UserProfile = {
   name: '게스트',
   email: '',
-  authority: 'ROLE_USER' // 기본 권한은 'ROLE_USER'
+  authority: 'ROLE_USER', // 기본 권한은 'ROLE_USER'
+  provider: ''
 };
 
 export const useUserStore = create<UserState>((set) => ({


### PR DESCRIPTION
## 연관된 이슈

> #77 

## 작업 내용

> - 프론트에서 관리하는 user에 provider(: EMAIL / KAKAO)를 추가했습니다.
> → user info 페이지에서 provider에 따라 회원 탈퇴 부분이 다르게 나타납니다.
> - 카카오톡으로 공유하기를 눌렀을 때 팝업 차단 정책으로 인해 오류가 나는 경우가 있다고 하여 해당 부분을 개선했습니다.

## 스크린샷 (선택)
<img width="400" alt="스크린샷 2025-04-11 124706" src="https://github.com/user-attachments/assets/acbb3afd-f93a-4426-9823-94f72e85d5e3" />

<img width="400" alt="스크린샷 2025-04-11 124905" src="https://github.com/user-attachments/assets/a95f4957-0f4f-4139-abd0-b04c53627283" />


## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #77